### PR TITLE
Addition of xtrabackup-24-buster

### DIFF
--- a/xtrabackup/fetch.sh
+++ b/xtrabackup/fetch.sh
@@ -1,0 +1,1 @@
+https://www.percona.com/downloads/Percona-XtraBackup-2.4/Percona-XtraBackup-2.4.26/binary/debian/buster/


### PR DESCRIPTION
This Pull Request adds `xtrabackup-24-buster` to the resources. We will need it when building new bootstrap images in Vitess.