### PR TITLE
update README.md with additional purpose (+testing) and releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vitess-resources
 
-External resources for Vitess builds
+External resources for Vitess builds and tests.
 
 This repo exists as a 3rd party and otherwise large external resources used for building open source [Vitess](https://github.com/vitessio/vitess).
 
@@ -8,4 +8,8 @@ We wish to reduce the 3rd party/external dependencies in the Vitess build proces
 
 Instead, we are incorporating these artifacts in _this_ repo. Since Vitess already depends on GitHub to build (hosted on GitHub, CI uses GitHub Actions), there is little increased risk. Moreover, we now pin down artifacts and can ensure they're never going away.
 
-Artifacts are uploaded as part of a `release`. For example, at this time we have `v1.0`: https://github.com/vitessio/vitess-resources/releases/tag/v1.0
+Artifacts are uploaded as part of a `release`. For example, at this time we have:
+
+ * `v3.0`: https://github.com/vitessio/vitess-resources/releases/tag/v3.0
+ * `v2.0`: https://github.com/vitessio/vitess-resources/releases/tag/v2.0
+ * `v1.0`: https://github.com/vitessio/vitess-resources/releases/tag/v1.0

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -1,0 +1,102 @@
+# Test data
+
+Test data for Vitess tests and benchmarks.
+
+## `enwiki-20080103-pages-articles.ibd.tar.zst`
+
+This Zstd archive is used in Vitess `mysqlctl` compression benchmarks:
+
+```sh
+vitessio/vitess $ go test -bench=BenchmarkCompress ./go/vt/mysqlctl -run=NONE -timeout=12h
+BenchmarkCompressLz4Builtin-8        1     59562955167 ns/op   1121.27 MB/s    3.101 compression-ratio/op
+BenchmarkCompressPargzipBuiltin-8    1    207188453500 ns/op    322.34 MB/s    2.937 compression-ratio/op
+...
+```
+
+The archive is built from a subset of [this Wikipedia XML archive](https://dumps.wikimedia.org/archive/enwiki/20080103/enwiki-20080103-pages-articles.xml.bz2).
+
+It is not included in this GitHub repository because it is too large. Instead, it is built locally and then attached to a GitHub release.
+
+To build the archive locally:
+
+ 1. Download and compile the `xml2sql` tool:
+    ```
+    $ git clone https://github.com/Tietew/mediawiki-xml2sql
+    $ cd mediawiki-xml2sql
+    mediawiki-xml2sql $ ./configure && make
+    $ cd ..
+    ```
+ 1. Download the Wikipedia XML data set:
+    ```sh
+    $ wget https://dumps.wikimedia.org/archive/enwiki/20080103/enwiki-20080103-pages-articles.xml.bz2
+    ```
+ 1. Convert the Wikipedia XML data set to MySQL `INSERT` statements:
+    ```
+    $ bunzip2 -c enwiki-20080103-pages-articles.xml.bz2 | ./mediawiki-xml2sql/xml2sql -m
+    ```
+ 1. Reduce the size of `text.sql` to 2GiB:
+    ```sh
+    $ truncate --no-create --size=2147483648 ./text.sql
+    ```
+ 1. Prepare a MySQL 8.0 database and tables:
+    ```sh
+    $ cat << EOF | mysql -u root
+    CREATE DATABASE enwiki;
+    USE enwiki;
+
+    CREATE TABLE `page` (
+      `page_id` int unsigned NOT NULL AUTO_INCREMENT,
+      `page_namespace` int NOT NULL,
+      `page_title` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+      `page_restrictions` tinyblob NOT NULL,
+      `page_counter` bigint unsigned NOT NULL DEFAULT '0',
+      `page_is_redirect` tinyint unsigned NOT NULL DEFAULT '0',
+      `page_is_new` tinyint unsigned NOT NULL DEFAULT '0',
+      `page_random` double unsigned NOT NULL,
+      `page_touched` binary(14) NOT NULL DEFAULT '\0\0\0\0\0\0\0\0\0\0\0\0\0\0',
+      `page_latest` int unsigned NOT NULL,
+      `page_len` int unsigned NOT NULL,
+      PRIMARY KEY (`page_id`),
+      UNIQUE KEY `name_title` (`page_namespace`,`page_title`),
+      KEY `page_random` (`page_random`),
+      KEY `page_len` (`page_len`)
+    ) ENGINE=InnoDB AUTO_INCREMENT=15071264 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    CREATE TABLE `revision` (
+      `rev_id` int unsigned NOT NULL AUTO_INCREMENT,
+      `rev_page` int unsigned NOT NULL,
+      `rev_text_id` int unsigned NOT NULL,
+      `rev_comment` mediumblob NOT NULL,
+      `rev_user` int unsigned NOT NULL DEFAULT '0',
+      `rev_user_text` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+      `rev_timestamp` char(14) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+      `rev_minor_edit` tinyint unsigned NOT NULL DEFAULT '0',
+      `rev_deleted` tinyint unsigned NOT NULL DEFAULT '0',
+      PRIMARY KEY (`rev_page`,`rev_id`),
+      UNIQUE KEY `rev_id` (`rev_id`),
+      KEY `rev_timestamp` (`rev_timestamp`),
+      KEY `page_timestamp` (`rev_page`,`rev_timestamp`),
+      KEY `user_timestamp` (`rev_user`,`rev_timestamp`),
+      KEY `usertext_timestamp` (`rev_user_text`,`rev_timestamp`)
+    ) ENGINE=InnoDB AUTO_INCREMENT=182440736 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    CREATE TABLE `text` (
+      `old_id` int unsigned NOT NULL AUTO_INCREMENT,
+      `old_text` mediumblob NOT NULL,
+      `old_flags` tinyblob NOT NULL,
+      PRIMARY KEY (`old_id`)
+    ) ENGINE=InnoDB AUTO_INCREMENT=182440736 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci MAX_ROWS=10000000 AVG_ROW_LENGTH=10240;
+    ```
+ 1. Load the SQL files into the database:
+    ```sh
+    $ cat *.sql | mysql -u root enwiki
+    # The last insert statement may fail because of the truncate. That's OK.
+    ```
+
+ 1. Create a tar file from the database InnoDB contents.
+    ```sh
+    $ mkdir enwiki-20080103-pages-articles
+    $ MYSQL_DATADIR="$(mysql -u root -sNe 'select @@datadir')"
+    $ cp ${MYSQL_DATADIR}/enwiki/*.ibd enwiki-20080103-pages-articles
+    $ tar -c - enwiki-20080103-pages-articles | zstd -19 -o enwiki-20080103-pages-articles.ibd.tar.zst
+    ```


### PR DESCRIPTION
[These benchmarks](https://github.com/vitessio/vitess/pull/11994) test the compression speed/ratio of various builtin and external compressors.

To ensure that we test a consistent and representative set of data. I pre-built a `.tar` file containing 3 InnoDB files. The InnoDB files were built by loading [this Wikipedia dataset](https://dumps.wikimedia.org/archive/enwiki/20080103/enwiki-20080103-pages-articles.xml.bz2) into MySQL 8.

Right now the file is located [here in DropBox](https://www.dropbox.com/s/smmgifsooy5qytd/enwiki-20080103-pages-articles.ibd.tar.zst?dl=0).

I was advised by @deepthi to think about uploading this file to `vitess-resources`. I recommend _not_ committing this file because it is so big. It will use up all of Vitess' LFS free storage and be a pain for anyone trying to clone the repo. 

Instead I would attach the file to a new release. You could prepend the release name with `testdata-` if you want to keep it separate from build-related artifacts.